### PR TITLE
fix/ make more visible tide level bar of current time

### DIFF
--- a/assets/js/lib/chartRender.js
+++ b/assets/js/lib/chartRender.js
@@ -5,6 +5,12 @@ export function renderChart() {
   const tideLevels = JSON.parse(chartArea.dataset.tideLevels);
 
   const date = document.querySelector(".date").dataset.date;
+  const currentHour = new Date().getHours();
+
+  const backgroundColors = tideLevels.map((_, index) =>
+    index === currentHour ? "rgba(255, 0, 54, 0.8)" : "rgba(54, 162, 235, 0.6)"
+  );
+
   const locationCode =
     document.querySelector(".location-code").dataset.locationCode;
 
@@ -16,6 +22,7 @@ export function renderChart() {
         {
           label: `${date} ${locationCode} Tide Levels`,
           data: tideLevels,
+          backgroundColor: backgroundColors,
           borderWidth: 1,
         },
       ],

--- a/assets/js/lib/chartRender.js
+++ b/assets/js/lib/chartRender.js
@@ -23,7 +23,8 @@ export function renderChart() {
     options: {
       scales: {
         y: {
-          beginAtZero: true,
+          max: 240,
+          min: -80,
         },
       },
     },

--- a/assets/js/lib/chartRender.js
+++ b/assets/js/lib/chartRender.js
@@ -10,6 +10,9 @@ export function renderChart() {
   const backgroundColors = tideLevels.map((_, index) =>
     index === currentHour ? "rgba(255, 0, 54, 0.8)" : "rgba(54, 162, 235, 0.6)"
   );
+  const pointRadius = tideLevels.map((_, index) =>
+    index === currentHour ? 5 : 0
+  );
 
   const locationCode =
     document.querySelector(".location-code").dataset.locationCode;
@@ -24,6 +27,15 @@ export function renderChart() {
           data: tideLevels,
           backgroundColor: backgroundColors,
           borderWidth: 1,
+        },
+        {
+          // FIXME: label は非表示にする
+          label: "",
+          data: tideLevels,
+          type: "line",
+          borderColor: "transparent",
+          pointBackgroundColor: "magenta",
+          pointRadius: pointRadius,
         },
       ],
     },


### PR DESCRIPTION
# About

- Dynamically change the bar color of the relevant time was changed, to make the current time's tide level bar more visible.
- Fixed Y-value range.

## Images

| before | after |
|--|--|
|<img width="802" alt="before" src="https://github.com/miolab/weather_cast_angle/assets/33124627/ce614f5a-2792-4d5c-876f-02806270bc92">|<img width="612" alt="after" src="https://github.com/miolab/weather_cast_angle/assets/33124627/8e2d9da8-7c95-49df-bbc3-432c23d64c62">|
| |Even if the bar graph does not appear due to a Y-value of 0 approximation, the current time can be intuitively grasped by the dot.<br><img width="618" alt="after2" src="https://github.com/miolab/weather_cast_angle/assets/33124627/bddfdc5c-b62f-4cc3-b3b2-f45bebf8263d">|

ref: https://github.com/miolab/weather_cast_angle/pull/5
