### PR TITLE
fix/ change wind speed and location name notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This app is specifically designed to provide comprehensive information on tide l
 
 - Screenshot during development;
 
-  <img width="607" alt="screenshot_during_development" src="https://github.com/miolab/weather_cast_angle/assets/33124627/e6f4f664-e32c-4828-9bc1-8cbefef49ab7">
+  <img width="607" alt="screenshot_during_development" src="https://github.com/miolab/weather_cast_angle/assets/33124627/6e37434d-09a4-40cb-8de4-be27cf313a9d">
 
 - The information provided by this application;
 

--- a/lib/weather_cast_angle/services/weather_current_data_handler.ex
+++ b/lib/weather_cast_angle/services/weather_current_data_handler.ex
@@ -49,7 +49,9 @@ defmodule WeatherCastAngle.Services.WeatherCurrentDataHandler do
           weather_main: weather_map |> Map.get("main"),
           weather_icon_uri:
             "https://openweathermap.org/img/wn/#{weather_map |> Map.get("icon")}@2x.png",
-          wind_speed: current_weather_response_map["wind"]["speed"] |> Float.round(1),
+          wind_speed:
+            current_weather_response_map["wind"]["speed"]
+            |> WeatherCastAngle.Services.WeatherDataProcessor.round_wind_speed(),
           main_temp:
             current_weather_response_map["main"]["temp"]
             |> WeatherCastAngle.Services.WeatherDataProcessor.kelvin_to_celsius_temperature(),

--- a/lib/weather_cast_angle/services/weather_data_processor.ex
+++ b/lib/weather_cast_angle/services/weather_data_processor.ex
@@ -51,6 +51,14 @@ defmodule WeatherCastAngle.Services.WeatherDataProcessor do
   end
 
   @doc """
+  Rounds the given wind speed to the nearest integer from float.
+  If an integer is given as an argument, it is returned as is.
+  """
+  @spec round_wind_speed(float() | non_neg_integer()) :: non_neg_integer()
+  def round_wind_speed(wind_speed) when is_float(wind_speed), do: round(wind_speed)
+  def round_wind_speed(wind_speed) when is_integer(wind_speed), do: wind_speed
+
+  @doc """
   Converts a float value to a percentage.
   This function is intended for use in the calculation of precipitation probability.
   """

--- a/lib/weather_cast_angle/services/weather_forecast_handler.ex
+++ b/lib/weather_cast_angle/services/weather_forecast_handler.ex
@@ -51,7 +51,9 @@ defmodule WeatherCastAngle.Services.WeatherForecastHandler do
           probability_of_precipitation:
             forecast_map["pop"]
             |> WeatherCastAngle.Services.WeatherDataProcessor.convert_to_percentage(),
-          wind_speed: forecast_map["wind"]["speed"] |> Float.round(1),
+          wind_speed:
+            forecast_map["wind"]["speed"]
+            |> WeatherCastAngle.Services.WeatherDataProcessor.round_wind_speed(),
           wind_deg: forecast_map["wind"]["deg"],
           main_temp:
             forecast_map["main"]["temp"]

--- a/lib/weather_cast_angle/utils/locations.ex
+++ b/lib/weather_cast_angle/utils/locations.ex
@@ -6,6 +6,7 @@ defmodule WeatherCastAngle.Utils.Locations do
           {
             String.t(),
             %{
+              place_name: String.t(),
               tide_location_code: String.t(),
               sea_area_code: non_neg_integer(),
               latitude: float(),
@@ -18,6 +19,7 @@ defmodule WeatherCastAngle.Utils.Locations do
       {
         "moji",
         %{
+          place_name: "門司",
           tide_location_code: "MO",
           sea_area_code: 602,
           latitude: 33.9484466691993,
@@ -27,6 +29,7 @@ defmodule WeatherCastAngle.Utils.Locations do
       {
         "hagi",
         %{
+          place_name: "萩",
           tide_location_code: "K5",
           sea_area_code: 601,
           # Senzaki
@@ -37,6 +40,7 @@ defmodule WeatherCastAngle.Utils.Locations do
       {
         "tokyo",
         %{
+          place_name: "東京",
           tide_location_code: "TK",
           sea_area_code: 306,
           latitude: 35.689499,
@@ -76,6 +80,7 @@ defmodule WeatherCastAngle.Utils.Locations do
   Return location map by input location name.
   """
   @spec get_location_map_by_name(String.t()) :: %{
+          place_name: String.t(),
           tide_location_code: String.t(),
           sea_area_code: non_neg_integer(),
           latitude: float(),
@@ -91,6 +96,14 @@ defmodule WeatherCastAngle.Utils.Locations do
   end
 
   @doc """
+  Get place name like '東京' or '門司' by location name.
+  """
+  @spec get_place_name_by_location_name(String.t()) :: String.t()
+  def get_place_name_by_location_name(location_name) do
+    get_location_map_by_name(location_name) |> Map.get(:place_name)
+  end
+
+  @doc """
   Get location code by location name.
   """
   @spec get_location_code_by_name(String.t()) :: String.t()
@@ -103,6 +116,7 @@ defmodule WeatherCastAngle.Utils.Locations do
     {
       "",
       %{
+        place_name: "",
         tide_location_code: "",
         sea_area_code: 0,
         latitude: 0.0,

--- a/lib/weather_cast_angle_web/controllers/page_html/home.html.heex
+++ b/lib/weather_cast_angle_web/controllers/page_html/home.html.heex
@@ -134,7 +134,7 @@
             value={location_name}
             selected={if location_name == @selected_location, do: "selected"}
           >
-            <%= location_name %>
+            <%= WeatherCastAngle.Utils.Locations.get_place_name_by_location_name(location_name) %>
           </option>
         <% end %>
       </select>

--- a/test/weather_cast_angle/services/weather_data_processor/round_wind_speed_test.exs
+++ b/test/weather_cast_angle/services/weather_data_processor/round_wind_speed_test.exs
@@ -1,0 +1,12 @@
+defmodule WeatherCastAngle.Services.WeatherDataProcessor.RoundWindSpeedTest do
+  use ExUnit.Case
+
+  test "Rounds the given wind speed string to the nearest integer." do
+    assert WeatherCastAngle.Services.WeatherDataProcessor.round_wind_speed(10.51) == 11
+    assert WeatherCastAngle.Services.WeatherDataProcessor.round_wind_speed(2.51) == 3
+    assert WeatherCastAngle.Services.WeatherDataProcessor.round_wind_speed(2.29) == 2
+    assert WeatherCastAngle.Services.WeatherDataProcessor.round_wind_speed(1) == 1
+    assert WeatherCastAngle.Services.WeatherDataProcessor.round_wind_speed(0.11) == 0
+    assert WeatherCastAngle.Services.WeatherDataProcessor.round_wind_speed(0) == 0
+  end
+end

--- a/test/weather_cast_angle/utils/locations/get_location_map_by_name_test.exs
+++ b/test/weather_cast_angle/utils/locations/get_location_map_by_name_test.exs
@@ -5,6 +5,7 @@ defmodule WeatherCastAngle.Utils.Locations.GetLocationMapByNameTest do
     actual = WeatherCastAngle.Utils.Locations.get_location_map_by_name("tokyo")
 
     assert actual == %{
+             place_name: "東京",
              tide_location_code: "TK",
              sea_area_code: 306,
              latitude: 35.689499,
@@ -16,6 +17,7 @@ defmodule WeatherCastAngle.Utils.Locations.GetLocationMapByNameTest do
     actual = WeatherCastAngle.Utils.Locations.get_location_map_by_name("undefined_location")
 
     assert actual == %{
+             place_name: "",
              tide_location_code: "",
              sea_area_code: 0,
              latitude: 0.0,


### PR DESCRIPTION
# About

- Round wind speed to integer.
- Enable to display of location selector by place name (like '東京', '門司').

## Images

| before | after |
|--|--|
|<img width="599" alt="bfr" src="https://github.com/miolab/weather_cast_angle/assets/33124627/d07c534c-891f-4add-b8f9-b5cfa6165583">|<img width="606" alt="aft" src="https://github.com/miolab/weather_cast_angle/assets/33124627/c8d33ddf-6faa-4957-b5a1-418490320bd4">|
