### PR TITLE
update/ Elixir version to 1.16.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.16.0-slim
+FROM elixir:1.16.1-slim
 
 RUN apt-get update && apt-get install -y git inotify-tools \
   python3 python3-pip


### PR DESCRIPTION
# About

Update Elixir version from 1.16.0 to 1.16.1.

https://github.com/elixir-lang/elixir/releases/tag/v1.16.1

ref: https://github.com/miolab/weather_cast_angle/pull/12