### PR TITLE
feat/ display weather forcast icon and wind speed in a chart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM elixir:1.16.1-slim
 
 RUN apt-get update && apt-get install -y git inotify-tools \
-  python3 python3-pip
+  python3.11 python3-pip python3.11-venv
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
 WORKDIR /app
@@ -18,6 +18,11 @@ COPY assets assets
 
 RUN mix do compile, phx.digest
 
-RUN pip3 install "erlport>=0.6" "ephem>=4.1,<5.0"
+# In compliance with PEP 668, create a virtual environment and install Python packages in it.
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+RUN pip3 install "erlport>=0.6"
+RUN pip3 install "ephem>=4.1,<5.0"
 
 CMD ["mix", "phx.server"]

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This app is specifically designed to provide comprehensive information on tide l
 - Marine information: Japan Meteorological Agency https://www.jma.go.jp/jma/kishou/info/coment.html
   - https://www.jma.go.jp/jma/menu/menureport.html
 - Weather information: OpenWeather https://openweathermap.org/full-price
-  - Current weather data: https://openweathermap.org/current#name
+  - Current weather data: https://openweathermap.org/current
   - 5 day weather forecast: https://openweathermap.org/forecast5
 - Moon information: calculate using PyEphem astronomy library for Python https://rhodesmill.org/pyephem/
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This app is specifically designed to provide comprehensive information on tide l
 
 - Screenshot during development;
 
-  <img width="607" alt="screenshot_during_development" src="https://github.com/miolab/weather_cast_angle/assets/33124627/6e37434d-09a4-40cb-8de4-be27cf313a9d">
+  <img width="607" alt="screenshot_during_development" src="https://github.com/miolab/weather_cast_angle/assets/33124627/2f50b738-5fed-43c4-9448-f757ea98015b">
 
 - The information provided by this application;
 
@@ -24,6 +24,15 @@ This app is specifically designed to provide comprehensive information on tide l
   - Moon age
   - Humidity
   - Seawater temperature
+
+### Source
+
+- Marine information: Japan Meteorological Agency https://www.jma.go.jp/jma/kishou/info/coment.html
+  - https://www.jma.go.jp/jma/menu/menureport.html
+- Weather information: OpenWeather https://openweathermap.org/full-price
+  - Current weather data: https://openweathermap.org/current#name
+  - 5 day weather forecast: https://openweathermap.org/forecast5
+- Moon information: calculate using PyEphem astronomy library for Python https://rhodesmill.org/pyephem/
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 
 This app is specifically designed to provide comprehensive information on tide levels, wind, weather, and more to help a fishing plan. :fish:
 
-<small>Note: This repository and application are designed for **personal use** only.</small>
-
 ## Features
 
 - Screenshot during development;
@@ -33,6 +31,11 @@ This app is specifically designed to provide comprehensive information on tide l
   - Current weather data: https://openweathermap.org/current
   - 5 day weather forecast: https://openweathermap.org/forecast5
 - Moon information: calculate using PyEphem astronomy library for Python https://rhodesmill.org/pyephem/
+
+### Disclaimer
+
+- This repository and application are designed for **personal use** only.
+- The use of this app is at your own risk. We assume no liability for any outcomes resulting from its use.
 
 ---
 

--- a/assets/js/lib/chartRender.ts
+++ b/assets/js/lib/chartRender.ts
@@ -51,35 +51,22 @@ const forecastDataPerHour: (ForecastData | "-")[] = hourScale.map((hour) => {
 });
 
 /**
- * Get weather temperature label per hour.
+ * Retrieves the forecast label for a specified attribute at a given hour, if available.
+ * It returns the attribute's value at 3-hour intervals, "-" for unavailable data, or
+ * an empty string for hours outside the 3-hour interval.
  *
  * @param {ForecastData | "-"} forecast - The forecast data for the hour, or "-" if not available.
- * @param {number} hour - The hour for which to get the temperature label.
- * @returns {string} The temperature label for the hour or "-" or empty string.
+ * @param {number} hour - The hour for which to get the forecast label.
+ * @param {keyof ForecastData} attribute - The forecast attribute to retrieve (e.g., "main_temp", "wind_speed").
+ * @returns {string} The forecast label for the hour or "-" or empty string.
  */
-const getWeatherTemperatureLabel = (
+const getForecastLabel = (
   forecast: ForecastData | "-",
-  hour: number
+  hour: number,
+  attribute: keyof ForecastData
 ): string => {
   if (hour % 3 === 0) {
-    return forecast !== "-" ? `${forecast.main_temp}` : "-";
-  }
-  return "";
-};
-
-/**
- * Get wind speed label per hour.
- *
- * @param {ForecastData | "-"} forecast - The forecast data for the hour, or "-" if not available.
- * @param {number} hour - The hour for which to get the wind speed label.
- * @returns {string} The wind speed label for the hour or "-" or empty string.
- */
-const getWindSpeedLabel = (
-  forecast: ForecastData | "-",
-  hour: number
-): string => {
-  if (hour % 3 === 0) {
-    return forecast !== "-" ? `${forecast.wind_speed}` : "-";
+    return forecast !== "-" ? `${forecast[attribute]}` : "-";
   }
   return "";
 };
@@ -163,12 +150,12 @@ export function renderChart(): void {
             if (element) {
               const x = element.x;
               ctx.fillText(
-                getWeatherTemperatureLabel(forecast, index),
+                getForecastLabel(forecast, index, "main_temp"),
                 x,
                 yPosition + 40
               );
               ctx.fillText(
-                getWindSpeedLabel(forecast, index),
+                getForecastLabel(forecast, index, "wind_speed"),
                 x,
                 yPosition + 60
               );

--- a/assets/js/lib/chartRender.ts
+++ b/assets/js/lib/chartRender.ts
@@ -68,6 +68,23 @@ const getWeatherTemperatureLabel = (
 };
 
 /**
+ * Get wind speed label per hour.
+ *
+ * @param {ForecastData | "-"} forecast - The forecast data for the hour, or "-" if not available.
+ * @param {number} hour - The hour for which to get the wind speed label.
+ * @returns {string} The wind speed label for the hour or "-" or empty string.
+ */
+const getWindSpeedLabel = (
+  forecast: ForecastData | "-",
+  hour: number
+): string => {
+  if (hour % 3 === 0) {
+    return forecast !== "-" ? `${forecast.wind_speed}` : "-";
+  }
+  return "";
+};
+
+/**
  * Renders a chart displaying tide levels for a specific location and date.
  *
  * - The chart displays tide levels for each hour over a 24-hour period.
@@ -121,21 +138,23 @@ export function renderChart(): void {
       },
       layout: {
         padding: {
-          bottom: 50,
+          // TODO: 天気アイコン・風向きを表示追加
+          bottom: 70,
         },
       },
       animation: {
         onComplete: () => {
+          // Render various forecast values.
           const ctx = chartInstance.ctx;
           ctx.font = "14px sans-serif";
           ctx.fillStyle = "blue";
           ctx.textAlign = "center";
 
-          // render `℃` label
           const yScale = chartInstance.scales["y"];
           const xPosition = yScale.left;
           const yPosition = yScale.bottom;
-          ctx.fillText("℃", xPosition + 15, yPosition + 40);
+          ctx.fillText("気温", xPosition + 15, yPosition + 40);
+          ctx.fillText("風速", xPosition + 15, yPosition + 60);
 
           forecastDataPerHour.forEach((forecast, index) => {
             const meta = chartInstance.getDatasetMeta(0);
@@ -147,6 +166,11 @@ export function renderChart(): void {
                 getWeatherTemperatureLabel(forecast, index),
                 x,
                 yPosition + 40
+              );
+              ctx.fillText(
+                getWindSpeedLabel(forecast, index),
+                x,
+                yPosition + 60
               );
             }
           });

--- a/assets/js/lib/chartRender.ts
+++ b/assets/js/lib/chartRender.ts
@@ -90,7 +90,7 @@ const drawWeatherForecastIcon = (
   if (hour % 3 === 0 && forecast !== "-") {
     const image = new Image();
     image.onload = () => {
-      ctx.drawImage(image, x - 14, y - 14, 25, 25);
+      ctx.drawImage(image, x - 14, y - 14, 24, 24);
     };
     image.src = forecast.weather_icon_uri;
   } else if (hour % 3 === 0) {
@@ -144,6 +144,8 @@ export function renderChart(): void {
       ],
     },
     options: {
+      responsive: true,
+      maintainAspectRatio: false,
       scales: {
         y: {
           max: 240,

--- a/assets/js/lib/chartRender.ts
+++ b/assets/js/lib/chartRender.ts
@@ -72,6 +72,33 @@ const getForecastLabel = (
 };
 
 /**
+ * Draw a weather icon or a placeholder "-" on the canvas at the specified position based on the availability of the forecast data.
+ *
+ * @param {CanvasRenderingContext2D} ctx - The rendering context of the canvas.
+ * @param {ForecastData | "-"} forecast - The forecast data for the hour, or "-" if not available.
+ * @param {number} hour - The hour for which to draw the icon.
+ * @param {number} x - The x-coordinate on the canvas where the icon should be drawn.
+ * @param {number} y - The y-coordinate on the canvas where the icon should be drawn.
+ */
+const drawWeatherForecastIcon = (
+  ctx: CanvasRenderingContext2D,
+  forecast: ForecastData | "-",
+  hour: number,
+  x: number,
+  y: number
+): void => {
+  if (hour % 3 === 0 && forecast !== "-") {
+    const image = new Image();
+    image.onload = () => {
+      ctx.drawImage(image, x - 14, y - 14, 25, 25);
+    };
+    image.src = forecast.weather_icon_uri;
+  } else if (hour % 3 === 0) {
+    ctx.fillText("-", x, y);
+  }
+};
+
+/**
  * Renders a chart displaying tide levels for a specific location and date.
  *
  * - The chart displays tide levels for each hour over a 24-hour period.
@@ -125,8 +152,8 @@ export function renderChart(): void {
       },
       layout: {
         padding: {
-          // TODO: 天気アイコン・風向きを表示追加
-          bottom: 70,
+          // TODO: 風向きを表示追加
+          bottom: 80,
         },
       },
       animation: {
@@ -142,6 +169,7 @@ export function renderChart(): void {
           const yPosition = yScale.bottom;
           ctx.fillText("気温", xPosition + 15, yPosition + 40);
           ctx.fillText("風速", xPosition + 15, yPosition + 60);
+          ctx.fillText("気象", xPosition + 15, yPosition + 80);
 
           forecastDataPerHour.forEach((forecast, index) => {
             const meta = chartInstance.getDatasetMeta(0);
@@ -159,6 +187,8 @@ export function renderChart(): void {
                 x,
                 yPosition + 60
               );
+
+              drawWeatherForecastIcon(ctx, forecast, index, x, yPosition + 80);
             }
           });
         },

--- a/lib/weather_cast_angle_web/controllers/page_html/home.html.heex
+++ b/lib/weather_cast_angle_web/controllers/page_html/home.html.heex
@@ -148,11 +148,11 @@
     </form>
 
     <div
-      class="js-weather-forecast"
+      class="js-weather-forecast relative h-auto min-h-[250px] sm:min-h-[350px]"
       data-weather-forecast={@weather_forecast_map |> Jason.encode!()}
     >
       <canvas
-        class="chart-area"
+        class="chart-area w-full h-full"
         data-tide-levels={@tide_response["hourly_tide_levels"] |> Jason.encode!()}
       >
       </canvas>


### PR DESCRIPTION
# About

Enable to display the 3 hourly __weather forecast icons__ and __wind speed__ in a chart.
Only forecasts that are available after the current time are displayed.

ref: https://github.com/miolab/weather_cast_angle/pull/27

## Images

| before | after |
| -- | -- |
|<img width="444" alt="bfr-pc" src="https://github.com/miolab/weather_cast_angle/assets/33124627/01f3d1df-3dee-44d9-b7a4-e66953169182">|<img width="444" alt="aft-pc" src="https://github.com/miolab/weather_cast_angle/assets/33124627/82e0c1a4-c8ac-4cf8-9c5a-c2abbeec9a5f">|
|<img width="220" alt="bfr-mobile" src="https://github.com/miolab/weather_cast_angle/assets/33124627/786a56d9-d829-4c63-b207-ab0ce4da6755">|<img width="220" alt="aft-mobile" src="https://github.com/miolab/weather_cast_angle/assets/33124627/70b47640-4015-4b3a-a6ed-cb32b7913228">|

## Other updates

- Add data source and disclaimer to README.
- In compliance with PEP 668, create a virtual environment and install Python packages in it.
```
RUN pip3 install "ephem>=4.1,<5.0":
0.658 error: externally-managed-environment
0.658 
0.658 × This environment is externally managed
0.658 ╰─> To install Python packages system-wide, try apt install
0.658     python3-xyz, where xyz is the package you are trying to
0.658     install.
0.658     
0.658     If you wish to install a non-Debian-packaged Python package,
0.658     create a virtual environment using python3 -m venv path/to/venv.
0.658     Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
0.658     sure you have python3-full installed.
0.658     
0.658     If you wish to install a non-Debian packaged Python application,
0.658     it may be easiest to use pipx install xyz, which will manage a
0.658     virtual environment for you. Make sure you have pipx installed.
```