### PR TITLE
feat/ enable to classify and display the tide name forecast

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This app is specifically designed to provide comprehensive information on tide l
 
 - Screenshot during development;
 
-  <img width="607" alt="screenshot_during_development" src="https://github.com/miolab/weather_cast_angle/assets/33124627/128e03b3-29d3-489b-893b-94c91d7f28fb">
+  <img width="600" alt="screenshot_during_development" src="https://github.com/user-attachments/assets/1ca61ed5-ad06-4445-b468-8c5aaeba36d8">
 
 - The information provided by this application;
 
@@ -32,6 +32,7 @@ This app is specifically designed to provide comprehensive information on tide l
 - Weather information: OpenWeather https://openweathermap.org/full-price
   - Current weather data: https://openweathermap.org/current
   - 5 day weather forecast: https://openweathermap.org/forecast5
+- Tide names classification: calculate using the difference in ecliptic longitude based on the MIRC method.
 - Moon information: calculate using PyEphem astronomy library for Python https://rhodesmill.org/pyephem/
 
 ### Disclaimer

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This app is specifically designed to provide comprehensive information on tide l
   - Temperature
   - Moon age
   - Humidity
+  - Tide name (e.g. 大潮, 小潮, 長潮, etc.)
   - Seawater temperature
   - Sunrise and Sunset time
 

--- a/lib/python_manager/py_modules/ecliptic_longitude_difference_calculator.py
+++ b/lib/python_manager/py_modules/ecliptic_longitude_difference_calculator.py
@@ -3,7 +3,7 @@ import math
 
 
 def _create_observer(date: bytes) -> ephem.Observer:
-    """Creates Ephem observer instance based on specified date, latitude, and longitude.
+    """Creates Ephem observer instance based on specified date.
 
     Args:
         date (str): 'yyyy/mm/dd' formatted date string.
@@ -18,7 +18,7 @@ def _create_observer(date: bytes) -> ephem.Observer:
 
 
 def calculate_ecliptic_longitude_difference(date: bytes) -> int:
-    """Calculates the ecliptic longitude difference between the sun and the moon at a given date and time and returns the angle (integer value).
+    """Calculates the ecliptic longitude difference between the sun and the moon at a given date and time and returns the angle.
 
     Args:
         date (str): 'yyyy/mm/dd' formatted date string.

--- a/lib/python_manager/py_modules/ecliptic_longitude_difference_calculator.py
+++ b/lib/python_manager/py_modules/ecliptic_longitude_difference_calculator.py
@@ -1,0 +1,35 @@
+import ephem
+import math
+
+
+def _create_observer(date: bytes) -> ephem.Observer:
+    """Creates Ephem observer instance based on specified date, latitude, and longitude.
+
+    Args:
+        date (str): 'yyyy/mm/dd' formatted date string.
+
+    Returns:
+        ephem.Observer: Ephem observer instance.
+    """
+    observer = ephem.Observer()
+    observer.date = date.decode("utf-8")
+
+    return observer
+
+
+def calculate_ecliptic_longitude_difference(date: bytes) -> int:
+    """Calculates the ecliptic longitude difference between the sun and the moon at a given date and time and returns the angle (integer value).
+
+    Args:
+        date (str): 'yyyy/mm/dd' formatted date string.
+
+    Returns:
+        int: the ecliptic longitude difference between the sun and the moon (in the range of 0 to 360 degrees).
+    """
+    observer = _create_observer(date)
+
+    sun, moon = ephem.Sun(observer), ephem.Moon(observer)
+    diff = (moon.hlon - sun.hlon) % (2 * math.pi)
+    diff_degree = math.degrees(diff)
+
+    return round(diff_degree)

--- a/lib/weather_cast_angle/services/tide_name_classifier.ex
+++ b/lib/weather_cast_angle/services/tide_name_classifier.ex
@@ -11,7 +11,7 @@ defmodule WeatherCastAngle.Services.TideNameClassifier do
   def get_ecliptic_longitude_difference(date) do
     date
     |> _get_ecliptic_longitude_difference_using_python()
-    |> classify_tide_name()
+    |> _classify_tide_name()
   end
 
   defp _get_ecliptic_longitude_difference_using_python(date) do
@@ -22,29 +22,28 @@ defmodule WeatherCastAngle.Services.TideNameClassifier do
     )
   end
 
-  @doc """
-  Classify the tide name based on the acliptic longitude difference.
-  """
-  @spec classify_tide_name(non_neg_integer()) :: String.t()
-  def classify_tide_name(angle) when angle >= 343 or angle < 31, do: "大潮"
-  def classify_tide_name(angle) when angle >= 163 and angle < 211, do: "大潮"
+  # Classify the tide name based on the ecliptic longitude difference.
+  @spec _classify_tide_name(non_neg_integer()) :: String.t()
+  defp _classify_tide_name(angle)
+       when angle >= 343 or angle < 31 or (angle >= 163 and angle < 211),
+       do: "大潮"
 
-  def classify_tide_name(angle)
-      when (angle >= 31 and angle < 67) or (angle >= 127 and angle < 163) or
-             (angle >= 211 and angle < 247) or (angle >= 307 and angle < 343),
-      do: "中潮"
+  defp _classify_tide_name(angle)
+       when (angle >= 31 and angle < 67) or (angle >= 127 and angle < 163) or
+              (angle >= 211 and angle < 247) or (angle >= 307 and angle < 343),
+       do: "中潮"
 
-  def classify_tide_name(angle)
-      when (angle >= 67 and angle < 103) or (angle >= 247 and angle < 283),
-      do: "小潮"
+  defp _classify_tide_name(angle)
+       when (angle >= 67 and angle < 103) or (angle >= 247 and angle < 283),
+       do: "小潮"
 
-  def classify_tide_name(angle)
-      when (angle >= 103 and angle < 115) or (angle >= 283 and angle < 295),
-      do: "長潮"
+  defp _classify_tide_name(angle)
+       when (angle >= 103 and angle < 115) or (angle >= 283 and angle < 295),
+       do: "長潮"
 
-  def classify_tide_name(angle)
-      when (angle >= 115 and angle < 127) or (angle >= 295 and angle < 307),
-      do: "若潮"
+  defp _classify_tide_name(angle)
+       when (angle >= 115 and angle < 127) or (angle >= 295 and angle < 307),
+       do: "若潮"
 
-  def classify_tide_name(_angle), do: "不明"
+  defp _classify_tide_name(_angle), do: "-"
 end

--- a/lib/weather_cast_angle/services/tide_name_classifier.ex
+++ b/lib/weather_cast_angle/services/tide_name_classifier.ex
@@ -1,0 +1,50 @@
+defmodule WeatherCastAngle.Services.TideNameClassifier do
+  @moduledoc """
+  Returns Tide Name based on the ecliptic longitude difference between the sun and the moon using erlport and Python script.
+  """
+  alias PythonManager.PythonExecutor
+
+  @doc """
+  Get the ecliptic longitude difference.
+  """
+  @spec get_ecliptic_longitude_difference(String.t()) :: String.t()
+  def get_ecliptic_longitude_difference(date) do
+    date
+    |> _get_ecliptic_longitude_difference_using_python()
+    |> classify_tide_name()
+  end
+
+  defp _get_ecliptic_longitude_difference_using_python(date) do
+    PythonExecutor.python_call(
+      :ecliptic_longitude_difference_calculator,
+      :calculate_ecliptic_longitude_difference,
+      [date]
+    )
+  end
+
+  @doc """
+  Classify the tide name based on the acliptic longitude difference.
+  """
+  @spec classify_tide_name(non_neg_integer()) :: String.t()
+  def classify_tide_name(angle) when angle >= 343 or angle < 31, do: "大潮"
+  def classify_tide_name(angle) when angle >= 163 and angle < 211, do: "大潮"
+
+  def classify_tide_name(angle)
+      when (angle >= 31 and angle < 67) or (angle >= 127 and angle < 163) or
+             (angle >= 211 and angle < 247) or (angle >= 307 and angle < 343),
+      do: "中潮"
+
+  def classify_tide_name(angle)
+      when (angle >= 67 and angle < 103) or (angle >= 247 and angle < 283),
+      do: "小潮"
+
+  def classify_tide_name(angle)
+      when (angle >= 103 and angle < 115) or (angle >= 283 and angle < 295),
+      do: "長潮"
+
+  def classify_tide_name(angle)
+      when (angle >= 115 and angle < 127) or (angle >= 295 and angle < 307),
+      do: "若潮"
+
+  def classify_tide_name(_angle), do: "不明"
+end

--- a/lib/weather_cast_angle_web/controllers/page_controller.ex
+++ b/lib/weather_cast_angle_web/controllers/page_controller.ex
@@ -7,6 +7,7 @@ defmodule WeatherCastAngleWeb.PageController do
   alias WeatherCastAngle.Services.WeatherCurrentDataHandler
   alias WeatherCastAngle.Services.WeatherForecastHandler
   alias WeatherCastAngle.Services.MoonStatusCalculator
+  alias WeatherCastAngle.Services.TideNameClassifier
   alias WeatherCastAngle.Services.SeaWaterTemperatureHandler
 
   @location_names Utils.Locations.location_names()
@@ -29,6 +30,7 @@ defmodule WeatherCastAngleWeb.PageController do
       location_names: @location_names,
       moon_age: _fetch_moon_status(current_date, location_name) |> Map.get("moon_age"),
       moon_phase: _fetch_moon_status(current_date, location_name) |> Map.get("moon_phase"),
+      tide_name: _get_tide_name_by_date(current_date),
       previous_days_sea_temperatures: _previous_days_sea_temperatures(location_name),
       # TODO: あとで消す
       current_weather_response: _fetch_current_weather_response_map(location_name),
@@ -74,6 +76,7 @@ defmodule WeatherCastAngleWeb.PageController do
       location_names: @location_names,
       moon_age: _fetch_moon_status(target_date, target_location_name) |> Map.get("moon_age"),
       moon_phase: _fetch_moon_status(target_date, target_location_name) |> Map.get("moon_phase"),
+      tide_name: _get_tide_name_by_date(target_date),
       previous_days_sea_temperatures: _previous_days_sea_temperatures(target_location_name),
       # TODO: あとで消す
       current_weather_response: _fetch_current_weather_response_map(target_location_name),
@@ -120,6 +123,9 @@ defmodule WeatherCastAngleWeb.PageController do
       "moon_phase" => MoonStatusCalculator.get_moon_phase(date, latitude, longitude)
     }
   end
+
+  defp _get_tide_name_by_date(date),
+    do: TideNameClassifier.get_ecliptic_longitude_difference(date)
 
   defp _previous_days_sea_temperatures(location_name),
     do: SeaWaterTemperatureHandler.get_previous_days_temperatures(location_name)

--- a/lib/weather_cast_angle_web/controllers/page_html/home.html.heex
+++ b/lib/weather_cast_angle_web/controllers/page_html/home.html.heex
@@ -13,9 +13,8 @@
           data-date={@tide_response.target_date}
         >
         </h2>
-        <span>
-          <%!-- TODO: --%>
-          <%!-- WIP --%>
+        <span class="text-xs sm:text-base">
+          <%= @tide_name %>
         </span>
       </div>
       <div class="text-center flex-none">

--- a/test/weather_cast_angle/services/tide_name_classifier/get_ecliptic_longitude_difference_test.exs
+++ b/test/weather_cast_angle/services/tide_name_classifier/get_ecliptic_longitude_difference_test.exs
@@ -1,0 +1,32 @@
+defmodule WeatherCastAngle.Services.TideNameClassifier.GetEclipticLongitudeDifferenceTest do
+  use ExUnit.Case
+
+  alias WeatherCastAngle.Services.TideNameClassifier
+
+  describe "Classifies tide name correctly based on angle." do
+    test "returns '大潮' for a date with a valid longitude difference in '大潮' range" do
+      actual = TideNameClassifier.get_ecliptic_longitude_difference("2025-01-01")
+      assert actual == "大潮"
+    end
+
+    test "returns '中潮' for a date with a valid longitude difference in '中潮' range" do
+      actual = TideNameClassifier.get_ecliptic_longitude_difference("2025-01-03")
+      assert actual == "中潮"
+    end
+
+    test "returns '小潮' for a date with a valid longitude difference in '小潮' range" do
+      actual = TideNameClassifier.get_ecliptic_longitude_difference("2025-01-06")
+      assert actual == "小潮"
+    end
+
+    test "returns '長潮' for a date with a valid longitude difference in '長潮' range" do
+      actual = TideNameClassifier.get_ecliptic_longitude_difference("2025-01-08")
+      assert actual == "長潮"
+    end
+
+    test "returns '若潮' for a date with a valid longitude difference in '若潮' range" do
+      actual = TideNameClassifier.get_ecliptic_longitude_difference("2025-01-09")
+      assert actual == "若潮"
+    end
+  end
+end


### PR DESCRIPTION
# About

Enable to display the __tide name__ (e.g. 大潮, 小潮, 長潮) forecast by date.

## Images

| before | after |
|--|--|
|<img width="604" alt="image" src="https://github.com/user-attachments/assets/416a57d6-4dce-46dc-8a71-b40373ab5eaf" />|<img width="613" alt="image" src="https://github.com/user-attachments/assets/52ed3df4-2628-4015-9328-cdfa02ba35ac" />|

## Ref

Tide names are classified by calculation using the difference in ecliptic longitude.
This logic uses the MIRC method.

https://ja.wikipedia.org/wiki/%E6%BD%AE%E6%B1%90
