### PR TITLE
fix/ re-display sea water temperature (previous days temperature from current)

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -20,10 +20,8 @@ renderChart();
 import { changeDateAndSubmit } from "./lib/changeDateAndSubmit";
 changeDateAndSubmit();
 
-import { formatDate } from "./lib/dateFormatter";
-const rawDateElement = document.querySelector(".js-format-japanese-date");
-const rawFormattedDate = rawDateElement.getAttribute("data-date");
-if (rawFormattedDate) rawDateElement.textContent = formatDate(rawFormattedDate);
+import { autoFormatJapaneseDates } from "./lib/dateFormatter";
+autoFormatJapaneseDates();
 
 import { MoonPhasePainter } from "./lib/moonPhasePainter";
 MoonPhasePainter.init();

--- a/assets/js/lib/dateFormatter.ts
+++ b/assets/js/lib/dateFormatter.ts
@@ -9,7 +9,22 @@ dayjs.locale("ja");
  * @param dateString - “YYYYY-MM-DD” formatted Date string.
  * @returns {string} - "1月23日(土)" formatted Date string in Japanese.
  */
-export function formatDate(dateString: string): string {
+const formatDate = (dateString: string): string => {
   const date = dayjs(dateString);
   return date.format("M月D日(ddd)");
-}
+};
+
+/**
+ * Finds all elements with the class `.js-format-japanese-date`,
+ * and formats their `data-date` attribute into Japanese date format.
+ */
+export const autoFormatJapaneseDates = (): void => {
+  document
+    .querySelectorAll<HTMLElement>(".js-format-japanese-date")
+    .forEach((element) => {
+      const rawDate = element.getAttribute("data-date");
+      if (rawDate) {
+        element.textContent = formatDate(rawDate);
+      }
+    });
+};

--- a/lib/weather_cast_angle/services/datetime_processor.ex
+++ b/lib/weather_cast_angle/services/datetime_processor.ex
@@ -61,4 +61,14 @@ defmodule WeatherCastAngle.Services.DatetimeProcessor do
   """
   @spec is_current_date(String.t()) :: boolean()
   def is_current_date(date), do: date == get_current_date_string()
+
+  @doc """
+  Get yesterday "Asia/Tokyo" date from current, and return the "YYYY-MM-DD" formatted date string.
+  """
+  @spec get_yesterday_string_from_current() :: String.t()
+  def get_yesterday_string_from_current() do
+    _get_current_date()
+    |> Timex.shift(days: -1)
+    |> Timex.format!("{YYYY}-{0M}-{0D}")
+  end
 end

--- a/lib/weather_cast_angle/services/sea_water_temperature_processor.ex
+++ b/lib/weather_cast_angle/services/sea_water_temperature_processor.ex
@@ -48,7 +48,7 @@ defmodule WeatherCastAngle.Services.SeaWaterTemperatureProcessor do
     temperature =
       temperature_string
       |> String.to_float()
-      |> Float.round(1)
+      |> round()
 
     {date, temperature}
   end

--- a/lib/weather_cast_angle_web/controllers/page_html/home.html.heex
+++ b/lib/weather_cast_angle_web/controllers/page_html/home.html.heex
@@ -72,7 +72,7 @@
       </canvas>
     </div>
 
-    <div class="flex justify-between items-center w-full mb-4">
+    <div class="flex justify-between items-start w-full mb-4">
       <div class="text-left flex-1">
         <div class="relative w-20 h-20">
           <svg
@@ -107,7 +107,8 @@
             >
               <path d="M440-760v-160h80v160h-80Zm266 110-55-55 112-115 56 57-113 113Zm54 210v-80h160v80H760ZM440-40v-160h80v160h-80ZM254-652 140-763l57-56 113 113-56 54Zm508 512L651-255l54-54 114 110-57 59ZM40-440v-80h160v80H40Zm157 300-56-57 112-112 29 27 29 28-114 114Zm283-100q-100 0-170-70t-70-170q0-100 70-170t170-70q100 0 170 70t70 170q0 100-70 170t-170 70Zm0-80q66 0 113-47t47-113q0-66-47-113t-113-47q-66 0-113 47t-47 113q0 66 47 113t113 47Zm0-160Z" />
             </svg>
-            日の出 <%= @sunrise %>
+            <span class="text-slate-900 text-sm items-center mr-2">日の出</span>
+            <%= @sunrise %>
           </span>
         </div>
         <div>
@@ -121,7 +122,8 @@
             >
               <path d="M504-425Zm20 385H420l20-12.5q20-12.5 43.5-28t43.5-28l20-12.5q81-6 149.5-49T805-285q-86-8-163-43.5T504-425q-61-61-97-138t-43-163q-77 43-120.5 118.5T200-444v12l-12 5.5q-12 5.5-26.5 11.5T135-403.5l-12 5.5q-2-11-2.5-23t-.5-23q0-146 93-257.5T450-840q-18 99 11 193.5T561-481q71 71 165.5 100T920-370q-26 144-138 237T524-40Zm-284-80h180q25 0 42.5-17.5T480-180q0-25-17-42.5T422-240h-52l-20-48q-14-33-44-52.5T240-360q-50 0-85 34.5T120-240q0 50 35 85t85 35Zm0 80q-83 0-141.5-58.5T40-240q0-83 58.5-141.5T240-440q60 0 109.5 32.5T423-320q57 2 97 42.5t40 97.5q0 58-41 99t-99 41H240Z" />
             </svg>
-            日没 <%= @sunset %>
+            <span class="text-slate-900 text-sm items-center mr-2">日没</span>
+            <%= @sunset %>
           </span>
         </div>
         <div>
@@ -141,16 +143,21 @@
           </span>
         </div>
       </div>
+      <div class="text-right flex-0 mr-1 bg-blue-50 px-2 py-1 border rounded-md ">
+        <p class="mb-0.5 text-xs sm:text-sm">
+          最近の<span class="font-medium">水温</span>
+        </p>
+        <ul class="list-inside text-xs">
+          <%= for {date, temperature} <- @previous_days_sea_temperatures do %>
+            <li>
+              <span class="js-format-japanese-date" data-date={date}></span>
+              <span class="text-sm ml-0.5"><%= temperature %></span>
+              <small>℃</small>
+            </li>
+          <% end %>
+        </ul>
+      </div>
       <%!-- TODO: 移行中 --%>
-      <%!-- WIP --%>
-      <div class="text-center flex-none">
-        <%!-- TODO: --%>
-        <%!-- WIP --%>
-      </div>
-      <div class="text-right flex-1">
-        <%!-- TODO: --%>
-        <%!-- WIP --%>
-      </div>
     </div>
 
     <%!-- TODO: 移行後削除 --%>

--- a/test/weather_cast_angle/services/datetime_processor/get_yesterday_string_test.exs
+++ b/test/weather_cast_angle/services/datetime_processor/get_yesterday_string_test.exs
@@ -1,0 +1,15 @@
+defmodule WeatherCastAngle.Services.DatetimeProcessor.GetYesterdayStringTest do
+  use ExUnit.Case
+  use Mimic
+
+  test "Get yesterday date and return the YYYY-MM-DD formatted date string." do
+    stub(
+      Timex,
+      :now,
+      fn "Asia/Tokyo" -> DateTime.from_naive!(~N[2025-01-01 12:00:00], "Asia/Tokyo") end
+    )
+
+    assert WeatherCastAngle.Services.DatetimeProcessor.get_yesterday_string_from_current() ==
+             "2024-12-31"
+  end
+end

--- a/test/weather_cast_angle/services/sea_water_temperature_processor/previous_days_records_test.exs
+++ b/test/weather_cast_angle/services/sea_water_temperature_processor/previous_days_records_test.exs
@@ -17,6 +17,10 @@ defmodule WeatherCastAngle.Services.SeaWaterTemperatureProcessor.PreviousDaysRec
     actual =
       WeatherCastAngle.Services.SeaWaterTemperatureProcessor.previous_days_records(raw_text)
 
-    assert actual == %{"2024-01-05" => 16.9, "2024-01-06" => 16.8, "2024-01-07" => 16.7}
+    assert actual == %{
+             "2024-01-05" => 17,
+             "2024-01-06" => 17,
+             "2024-01-07" => 17
+           }
   end
 end


### PR DESCRIPTION
# About

Re-display the previous day's seawater temperatures from current day.

## Images

| before | after |
|--|--|
|<image width="363" src="https://github.com/user-attachments/assets/18595da1-3ef3-4f3c-a203-0c900a15b319">|<img width="368" alt="image" src="https://github.com/user-attachments/assets/a850b024-e7f2-4e4f-a5f7-db650a4c6672" />|

- ref: https://github.com/miolab/weather_cast_angle/pull/23 , https://github.com/miolab/weather_cast_angle/pull/50
